### PR TITLE
Allow other hash values

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function PipeHash (opts, callback) {
   this._opts = {}
 
   // hash: custom std crypto hash, or 1st default blake2b, 2nd default sha512
-  this._opts.hash = opts.hash || blake2b.SUPPORTED ? 'blake2b' : 'sha512'
+  this._opts.hash = opts.hash || (blake2b.SUPPORTED ? 'blake2b' : 'sha512')
   this._blake2b = this._opts.hash === 'blake2b'
   this._blake2b_READY = false
   this._opts.blake2bArgs = [


### PR DESCRIPTION
Currently if you try to set the `hash` option, it will always be overwritten to `blake2b`.